### PR TITLE
Update download-manifest.py

### DIFF
--- a/download-manifest.py
+++ b/download-manifest.py
@@ -47,7 +47,7 @@ def main():
         if "/" not in repo:
             repo = "library/" + repo
         pretty_print(download_manifest_for_repo(repo, tag))
-        return 0
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
re-indenting return re-enables repeated `repo_tag` retrieval